### PR TITLE
Add new configuration option to disable ARMA 3 artillery computer

### DIFF
--- a/client/init.sqf
+++ b/client/init.sqf
@@ -91,6 +91,7 @@ if (["A3W_playerSaving"] call isConfigOn) then
 	});
 };
 
+
 if (isNil "playerData_alive") then
 {
 	player call playerSetupGear;
@@ -162,3 +163,8 @@ call compile preprocessFileLineNumbers "client\functions\generateAtmArray.sqf";
 		};
 	} forEach crew _x;
 } forEach allUnitsUAV;
+
+if (["A3W_disableArtilleryComputer"] call isConfigOn) then
+{
+  enableEngineArtillery false;
+};

--- a/server/default_config.sqf
+++ b/server/default_config.sqf
@@ -27,6 +27,7 @@ A3W_donatorEnabled = 1;				// Enable/Disable Donator Features
 A3W_customUniformEnabled = 1;		// Enable/Disable Custom Uniforms
 A3W_tkAutoKickEnabled = 1;			// Enable/Disable Autokick for teamkillers
 A3W_tkKickAmount = 10;			// TeamKill amount needed before Kick.
+A3W_disableArtilleryComputer = 0;  // Disable use of the ARMA 3 artillery computer for artillery/ortars
 
 // Store settings
 A3W_showGunStoreStatus = 1;        // Show enemy and friendly presence at gunstores on map (0 = no, 1 = yes)


### PR DESCRIPTION
This commit adds a new option "A3W_disableArtilleryComputer" to the config file, if set to 1 - it will disable the inbuilt ARMA 3 artillery computer for all vehicles/static weapons that utilize it - making the affected vehicles/weapons more balanced in a Wasteland environemnt.

This will force players to learn how to calculate artillery trajectories manually (e.g. https://www.youtube.com/watch?v=SCCvXfwzeAU), or use a spotter to adjust the trajectory on the fly rather than for example, drop 10 GRAD shells on an occupied gun store with point and click accuracy.
